### PR TITLE
Enable SDL3 on linux

### DIFF
--- a/build_linux.sh
+++ b/build_linux.sh
@@ -24,7 +24,7 @@ fi
         -chr 0 -drc 1 -sss 4 \
         -fullscreen 0 \
         -var-fullscreen 1 \
-        -api sd2 \
+        -api sd3 \
         > setup.sh
 
 # generate makefile and build


### PR DESCRIPTION
Let's use SDL3, only issue is with wayland
`SDL_SetWindowPosition fails: wayland cannot position non-popup windows`
needs to run with `SDL_VIDEODRIVER=x11 ./minivmac`

BTW, got Mini vMac working on power mac g5 running archlinux with SDL3 too