### PR TITLE
Add Linux ppc64 target (-t lp64) and CPU family p64

### DIFF
--- a/setup/GNBLDOPT.i
+++ b/setup/GNBLDOPT.i
@@ -355,6 +355,7 @@ enum {
         gbk_targ_wx64, /* Windows on x64 */
         gbk_targ_lx86, /* X11 for linux on x86 */
         gbk_targ_lppc, /* X11 for linux on PowerPC */
+        gbk_targ_lp64, /* X11 for linux on PowerPC64 */
         gbk_targ_lx64, /* X11 for linux on x64 */
         gbk_targ_larm, /* X11 for linux on arm (debian armel) */
         gbk_targ_lspr, /* X11 for linux on SPARC */
@@ -491,6 +492,9 @@ LOCALFUNC char * GetTargetName(int i)
 			break;
 		case gbk_targ_lppc:
 			s = "lppc";
+			break;
+		case gbk_targ_lp64:
+			s = "lp64";
 			break;
 		case gbk_targ_lx64:
 			s = "lx64";
@@ -893,6 +897,7 @@ enum {
 	gbk_cpufam_mip, /* MIPS */
 	gbk_cpufam_gen, /* Generic (don't know) */
 	gbk_cpufam_a64, /* ARM64 */
+	gbk_cpufam_p64, /* PowerPC64 */
 	kNumCPUFamilies
 };
 
@@ -937,6 +942,9 @@ LOCALFUNC char * GetCPUFamName(int i)
 		case gbk_cpufam_a64:
 			s = "a64";
 			break;
+		case gbk_cpufam_p64:
+			s = "p64";
+			break;
 		default:
 			s = "(unknown CPU)";
 			break;
@@ -966,6 +974,9 @@ LOCALFUNC int dfo_cpufam(void)
 		case gbk_targ_lppc:
 		case gbk_targ_fbpc:
 			v = gbk_cpufam_ppc;
+			break;
+		case gbk_targ_lp64:
+			v = gbk_cpufam_p64;
 			break;
 		case gbk_targ_wx86:
 		case gbk_targ_wc86:
@@ -1085,6 +1096,7 @@ LOCALFUNC tMyErr ChooseTargFam(void)
                         break;
 		case gbk_targ_lx86:
 		case gbk_targ_lppc:
+		case gbk_targ_lp64:
 		case gbk_targ_lx64:
 		case gbk_targ_larm:
 		case gbk_targ_lspr:

--- a/setup/SPOTHRCF.i
+++ b/setup/SPOTHRCF.i
@@ -747,7 +747,9 @@ LOCALPROC WriteAppCNFUDPICcontents(void)
 			WriteDestFileLn("#define r_pc_pHi \"r13\"");
 		}
 
-		if (gbk_cpufam_ppc == gbo_cpufam) {
+		if ((gbk_cpufam_ppc == gbo_cpufam)
+			|| (gbk_cpufam_p64 == gbo_cpufam))
+		{
 			WriteBlankLineToDestFile();
 			WriteDestFileLn("#define r_regs \"r14\"");
 			WriteDestFileLn("#define r_pc_p \"r15\"");

--- a/setup/WRCNFGGL.i
+++ b/setup/WRCNFGGL.i
@@ -61,6 +61,9 @@ LOCALPROC WriteCommonCNFUIALLContents(void)
 			case gbk_cpufam_ppc:
 				WriteCheckPreDef("__POWERPC__");
 				break;
+			case gbk_cpufam_p64:
+				WriteCheckPreDef("__POWERPC64__");
+				break;
 			case gbk_cpufam_x86:
 				WriteCheckPreDef("__INTEL__");
 				break;
@@ -82,6 +85,18 @@ LOCALPROC WriteCommonCNFUIALLContents(void)
 					" 64 bit compiler\"");
 				WriteDestFileLn("#endif");
 				break;
+			case gbk_cpufam_ppc:
+				WriteDestFileLn("#ifdef __powerpc__");
+				WriteDestFileLn("#error \"source is configured for"
+					" 32 bit compiler\"");
+				WriteDestFileLn("#endif");
+				break;
+			case gbk_cpufam_p64:
+				WriteDestFileLn("#ifndef __powerpc64__");
+				WriteDestFileLn("#error \"source is configured for"
+					" 64 bit compiler\"");
+				WriteDestFileLn("#endif");
+				break;
 		}
 	}
 
@@ -90,13 +105,15 @@ LOCALPROC WriteCommonCNFUIALLContents(void)
 #if NeedIntFormatInfo
 	WriteCompCondBool("MostSigByteFirst",
 		(gbk_cpufam_68k == gbo_cpufam)
-		|| (gbk_cpufam_ppc == gbo_cpufam));
+		|| (gbk_cpufam_ppc == gbo_cpufam)
+		|| (gbk_cpufam_p64 == gbo_cpufam));
 	WriteCompCondBool("LeastSigByteFirst",
 		(gbk_cpufam_x86 == gbo_cpufam)
 		|| (gbk_cpufam_x64 == gbo_cpufam));
 	WriteCompCondBool("TwosCompSigned",
 		(gbk_cpufam_68k == gbo_cpufam)
 		|| (gbk_cpufam_ppc == gbo_cpufam)
+		|| (gbk_cpufam_p64 == gbo_cpufam)
 		|| (gbk_cpufam_x86 == gbo_cpufam)
 		|| (gbk_cpufam_x64 == gbo_cpufam));
 #endif
@@ -149,7 +166,8 @@ LOCALPROC WriteCommonCNFUIALLContents(void)
 
 	if (gbk_ide_mvc == cur_ide) {
 		if ((gbk_cpufam_68k == gbo_cpufam)
-			|| (gbk_cpufam_ppc == gbo_cpufam))
+			|| (gbk_cpufam_ppc == gbo_cpufam)
+			|| (gbk_cpufam_p64 == gbo_cpufam))
 		{
 			WriteDestFileLn("#define BigEndianUnaligned 1");
 			WriteDestFileLn("#define LittleEndianUnaligned 0");
@@ -185,6 +203,7 @@ LOCALPROC WriteCommonCNFUIALLContents(void)
 		}
 		if ((gbk_cpufam_x64 == gbo_cpufam)
 			|| (gbk_cpufam_ppc == gbo_cpufam)
+			|| (gbk_cpufam_p64 == gbo_cpufam)
 			|| (gbk_cpufam_arm == gbo_cpufam))
 		{
 			WriteDestFileLn("#define HaveGlbReg 1");
@@ -328,7 +347,8 @@ LOCALPROC WriteCommonCNFUIALLContents(void)
 	/* (ui5b)0 - (ui5b)1 == (ui5b)4294967295 */
 	WriteBlankLineToDestFile();
 	if ((gbk_cpufam_x64 == gbo_cpufam)
-		|| (gbk_cpufam_a64 == gbo_cpufam))
+		|| (gbk_cpufam_a64 == gbo_cpufam)
+		|| (gbk_cpufam_p64 == gbo_cpufam))
 	{
 		WriteDestFileLn("typedef unsigned int ui5b;");
 	} else {
@@ -339,7 +359,8 @@ LOCALPROC WriteCommonCNFUIALLContents(void)
 	/* sizeof(si5b) == sizeof(ui5b) */
 	WriteBlankLineToDestFile();
 	if ((gbk_cpufam_x64 == gbo_cpufam)
-		|| (gbk_cpufam_a64 == gbo_cpufam))
+		|| (gbk_cpufam_a64 == gbo_cpufam)
+		|| (gbk_cpufam_p64 == gbo_cpufam))
 	{
 		WriteDestFileLn("typedef int si5b;");
 	} else {
@@ -378,7 +399,9 @@ LOCALPROC WriteCommonCNFUIALLContents(void)
 
 	WriteBlankLineToDestFile();
 #if ModPPCi3rTypes
-	if (gbk_cpufam_ppc == gbo_cpufam) {
+	if ((gbk_cpufam_ppc == gbo_cpufam)
+		|| (gbk_cpufam_p64 == gbo_cpufam))
+	{
 		WriteDestFileLn("typedef ui5b ui3r;");
 		WriteDestFileLn("#define ui3beqr 0");
 	} else
@@ -390,7 +413,9 @@ LOCALPROC WriteCommonCNFUIALLContents(void)
 
 	WriteBlankLineToDestFile();
 #if ModPPCi3rTypes
-	if (gbk_cpufam_ppc == gbo_cpufam) {
+	if ((gbk_cpufam_ppc == gbo_cpufam)
+		|| (gbk_cpufam_p64 == gbo_cpufam))
+	{
 		WriteDestFileLn("typedef si5b si3r;");
 		WriteDestFileLn("#define si3beqr 0");
 	} else

--- a/setup/WRMVCFLS.i
+++ b/setup/WRMVCFLS.i
@@ -322,6 +322,9 @@ LOCALPROC WriteMVCMakeFile(void)
 		case gbk_targ_lppc:
 			WriteDestFileLn("my_prefix = powerpc-linux-gnu-");
 			break;
+		case gbk_targ_lp64:
+			WriteDestFileLn("my_prefix = powerpc64-linux-gnu-");
+			break;
 		case gbk_targ_lspr:
 			WriteDestFileLn("my_prefix = sparc-linux-gnu-");
 			break;
@@ -518,6 +521,7 @@ LOCALPROC WriteMVCMakeFile(void)
 					case gbk_targ_lx64:
 					case gbk_targ_larm:
 					case gbk_targ_lppc:
+					case gbk_targ_lp64:
 					case gbk_targ_lspr:
 					case gbk_targ_fbsd:
 					case gbk_targ_fb64:


### PR DESCRIPTION
Add Linux PowerPC 64-bit build target (lp64 / p64)

- Introduce gbk_targ_lp64 (-t lp64) with powerpc64-linux-gnu- toolchain prefix.
- Extend generated logic for p64: big-endian flags.
- Treat p64 like ppc for global-register bindings.
- Link flags: include lp64 with other Linux targets using -static-libgcc.

<img width="1920" height="1079" alt="Screenshot 2026-04-12 at 11 31 59" src="https://github.com/user-attachments/assets/81ce9487-cfe0-43cd-8111-84b7d9a65bf6" />

