### PR TITLE
sdl3: wayland cannot position non-popup windows

### DIFF
--- a/src/OSGLUSDL.c
+++ b/src/OSGLUSDL.c
@@ -4347,6 +4347,8 @@ LOCALFUNC blnr CreateMainWindow(void)
 	#if SDL_MAJOR_VERSION >= 3
 	} else
 	if (
+		/* wayland does not support setting window position */
+		strcmp(SDL_GetCurrentVideoDriver(), "wayland") &&
 		!SDL_SetWindowPosition(
 			my_main_wind,
 			NewWindowX,


### PR DESCRIPTION
Running `minivmac` under Wayland crashes with the following error:

```
[tavispalmer@fedora minivmac]$ ./minivmac
SDL_SetWindowPosition fails: wayland cannot position non-popup windows
```

I have added a video driver check before attempting to set the window position in order to prevent this.

Note that this should be a *runtime* check, since not all Linux systems run Wayland.